### PR TITLE
fix: Don't refer to issue 3, it clutters the references

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request.md
@@ -1,5 +1,5 @@
 <!--
-The title of the pull request should follow this format: 
+The title of the pull request should follow this format:
 
 type(scope): description
 
@@ -24,8 +24,6 @@ types:
 
 ## Related issues
 
-> Fix #3
-
 ## Checklists
 
 ### Development
@@ -34,7 +32,6 @@ types:
 - [ ] The code changed/added as part of this pull request has been covered with tests
 - [ ] All tests related to the changed code pass in development
 
-### Code review 
+### Code review
 
 - [ ] Changes have been reviewed by at least one other engineer
-


### PR DESCRIPTION
## Description of the change

There are many PRs that don't update the "Related issues" section. So any issue with ID 3 is bound to have a bunch of references to it in our projects.


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (Changed implementation, but existing functionality and APIs are not changed)

## Related issues

> Fix #3

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] Changes have been reviewed by at least one other engineer

