### PR TITLE
fix: Remove "Type of change" section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request.md
@@ -1,26 +1,6 @@
-<!--
-The title of the pull request should follow this format: 
 
-type(scope): description
-
-types:
-
-- fix
-- feat
-- refactor
-- docs
-- chore
--->
-
-## Description of the change
 
 > Description here
-
-## Type of change
-- [ ] Bug fix (non-breaking change that fixes an issue)
-- [ ] New feature (non-breaking change that adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Refactor (Changed implementation, but existing functionality and APIs are not changed)
 
 ## Related issues
 


### PR DESCRIPTION
Removes the "Type of change" section, since we are using conventional commits. 

Removes the "Description" heading since the first text will naturally be the description.

## Related issues

Fixes #7 
Fixes #9 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] Changes have been reviewed by at least one other engineer

